### PR TITLE
Fullscreen widgets support

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,10 +158,6 @@ widget.modifySection(section);
 
 The `title` of a given section has to match the one specified in the initial state. Otherwise, the section won't change. Also, the Agent App ignores the commands without valid section definitions. Make sure that the definition you're sending is correct.
 
-#### `setNotifications({ fullscreen?: number }): Promise<void>`
-
-Displays a notification in one of the supported app locations. Only one location is supported at this moment (`fullscreen`) – it displays a red badge on top of the FullScreen app icon.
-
 ## MessageBox widget (`IMessageBoxWidget`)
 
 ### Events
@@ -210,3 +206,15 @@ Gets the customer profile recorded most recently. Returns the `ICustomerProfile`
 - `elements.buttons.postback_id` describes the action sent via the `send_rich_message_postback` method
 - multiple buttons (even from different elements) can contain the same `postback_id`; calling `send_rich_message_postback` with this id will add a user to all these buttons at once.
 - `elements.buttons.user_ids` describes users who sent the postback with `"toggled": true`
+
+## Fullscreen widget (`IFullscreenWidget`)
+
+### Events
+
+This widget currently does not support any events.
+
+### Methods
+
+#### `displayNotification(count: number | null): Promise<void>`
+
+Displays a red badge on top of the Fullscreen app icon. Use this to notify Agents there’s something important inside the widget. Make sure Agents can dismiss the notification to avoid cluttered UI.

--- a/README.md
+++ b/README.md
@@ -158,6 +158,10 @@ widget.modifySection(section);
 
 The `title` of a given section has to match the one specified in the initial state. Otherwise, the section won't change. Also, the Agent App ignores the commands without valid section definitions. Make sure that the definition you're sending is correct.
 
+#### `setNotifications({ fullscreen?: number }): Promise<void>`
+
+Displays a notification in one of the supported app locations. Only one location is supported at this moment (`fullscreen`) – it displays a red badge above FullScreen app icon.
+
 ## MessageBox widget (`IMessageBoxWidget`)
 
 ### Events

--- a/README.md
+++ b/README.md
@@ -215,6 +215,6 @@ This widget currently does not support any events.
 
 ### Methods
 
-#### `displayNotification(count: number | null): Promise<void>`
+#### `setNotificationBadge(count: number | null): Promise<void>`
 
 Displays a red badge on top of the Fullscreen app icon. Use this to notify Agents there’s something important inside the widget. Make sure Agents can dismiss the notification to avoid cluttered UI.

--- a/README.md
+++ b/README.md
@@ -160,7 +160,7 @@ The `title` of a given section has to match the one specified in the initial sta
 
 #### `setNotifications({ fullscreen?: number }): Promise<void>`
 
-Displays a notification in one of the supported app locations. Only one location is supported at this moment (`fullscreen`) – it displays a red badge above FullScreen app icon.
+Displays a notification in one of the supported app locations. Only one location is supported at this moment (`fullscreen`) – it displays a red badge on top of the FullScreen app icon.
 
 ## MessageBox widget (`IMessageBoxWidget`)
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@livechat/agent-app-sdk",
-  "version": "1.3.0",
+  "version": "1.4.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -1955,7 +1955,8 @@
         "ansi-regex": {
           "version": "2.1.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -1976,12 +1977,14 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -1996,17 +1999,20 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -2123,7 +2129,8 @@
         "inherits": {
           "version": "2.0.3",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "ini": {
           "version": "1.3.5",
@@ -2135,6 +2142,7 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -2149,6 +2157,7 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -2156,12 +2165,14 @@
         "minimist": {
           "version": "0.0.8",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "minipass": {
           "version": "2.3.5",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
@@ -2180,6 +2191,7 @@
           "version": "0.5.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -2260,7 +2272,8 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -2272,6 +2285,7 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -2357,7 +2371,8 @@
         "safe-buffer": {
           "version": "5.1.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -2393,6 +2408,7 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -2412,6 +2428,7 @@
           "version": "3.0.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -2455,12 +2472,14 @@
         "wrappy": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "yallist": {
           "version": "3.0.3",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@livechat/agent-app-sdk",
-  "version": "1.3.0",
+  "version": "1.4.0",
   "description": "SDK for extending LiveChat's Agent App",
   "license": "MIT",
   "repository": {

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,2 +1,3 @@
 export { createDetailsWidget } from './widgets/details';
 export { createMessageBoxWidget } from './widgets/messagebox';
+export { createFullscreenWidget } from './widgets/fullscreen';

--- a/src/widgets/fullscreen/fullscreen-widget.ts
+++ b/src/widgets/fullscreen/fullscreen-widget.ts
@@ -1,0 +1,25 @@
+import { createWidget } from '../shared/widget';
+import { withAmplitude } from '../shared/amplitude';
+import { IConnection, createConnection } from '../connection';
+import { IFullscreenWidgetApi, IFullscreenWidgetEvents } from './interfaces';
+
+function FullscreenWidget(connection: IConnection<IFullscreenWidgetEvents>) {
+  const base = createWidget<IFullscreenWidgetApi, IFullscreenWidgetEvents>(
+    connection,
+    {
+      displayNotification(count: number | null): Promise<void> {
+        return connection.sendMessage('display_fullscreen_notification', count);
+      }
+    }
+  );
+  return withAmplitude(base);
+}
+
+export interface IFullscreenWidget
+  extends ReturnType<typeof FullscreenWidget> {}
+
+export default function createFullscreenWidget(): Promise<IFullscreenWidget> {
+  return createConnection<IFullscreenWidgetEvents>().then(connection =>
+    FullscreenWidget(connection)
+  );
+}

--- a/src/widgets/fullscreen/fullscreen-widget.ts
+++ b/src/widgets/fullscreen/fullscreen-widget.ts
@@ -7,8 +7,11 @@ function FullscreenWidget(connection: IConnection<IFullscreenWidgetEvents>) {
   const base = createWidget<IFullscreenWidgetApi, IFullscreenWidgetEvents>(
     connection,
     {
-      displayNotification(count: number | null): Promise<void> {
-        return connection.sendMessage('display_fullscreen_notification', count);
+      setNotificationBadge(count: number | null): Promise<void> {
+        return connection.sendMessage(
+          'set_fullscreen_app_notification_badge',
+          count
+        );
       }
     }
   );

--- a/src/widgets/fullscreen/index.ts
+++ b/src/widgets/fullscreen/index.ts
@@ -1,0 +1,4 @@
+export {
+  default as createFullscreenWidget,
+  IFullscreenWidget
+} from './fullscreen-widget';

--- a/src/widgets/fullscreen/interfaces.ts
+++ b/src/widgets/fullscreen/interfaces.ts
@@ -1,5 +1,5 @@
 export interface IFullscreenWidgetApi {
-  displayNotification(count: number | null): void;
+  setNotificationBadge(count: number | null): void;
 }
 
 export interface IFullscreenWidgetEvents {}

--- a/src/widgets/fullscreen/interfaces.ts
+++ b/src/widgets/fullscreen/interfaces.ts
@@ -1,0 +1,5 @@
+export interface IFullscreenWidgetApi {
+  displayNotification(count: number | null): void;
+}
+
+export interface IFullscreenWidgetEvents {}


### PR DESCRIPTION
Support for `createFullscreenWidget()` and `widget.displayNotification(...)` API. It allows developers to display a red notification badge on top of the Fullscreen app icon.