### PR TITLE
Fixed groupID type from string to number

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,7 +116,7 @@ interface ICustomerProfile {
   email?: string;
   chat: {
     id?: string;
-    groupID: string;
+    groupID: number;
     preChatSurvey: { question: string; answer: string }[];
   };
   source: 'chats' | 'archives' | 'customers';

--- a/src/widgets/shared/customer-profile.ts
+++ b/src/widgets/shared/customer-profile.ts
@@ -15,7 +15,7 @@ export interface ICustomerProfile {
   email?: string;
   chat: {
     id: string;
-    groupID: string;
+    groupID: number;
     preChatSurvey?: { question: string; answer: string }[];
   };
   source: 'chats' | 'archives' | 'customers';


### PR DESCRIPTION
`chat.groupID` has an incorrect type definition. It should be `number`, not a `string`.